### PR TITLE
src変更時の自動ビルド・コミットワークフローを追加

### DIFF
--- a/.github/workflows/build-and-commit.yml
+++ b/.github/workflows/build-and-commit.yml
@@ -1,0 +1,56 @@
+name: Auto Build and Commit
+
+on:
+  push:
+    branches:
+      - main
+    paths:
+      - 'src/**'
+      - 'package.json'
+      - 'package-lock.json'
+      - 'tsconfig.json'
+
+permissions:
+  contents: write
+
+jobs:
+  build-and-commit:
+    runs-on: ubuntu-latest
+    # [skip ci]を含むコミットでは実行しない（無限ループ防止）
+    if: "!contains(github.event.head_commit.message, '[skip ci]')"
+    
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+        with:
+          token: ${{ secrets.GITHUB_TOKEN }}
+          fetch-depth: 0
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: '20'
+
+      - name: Install dependencies
+        run: npm install
+
+      - name: Build
+        run: npm run build
+
+      - name: Check for changes
+        id: check-changes
+        run: |
+          if [ -n "$(git status --porcelain dist/)" ]; then
+            echo "has_changes=true" >> $GITHUB_OUTPUT
+          else
+            echo "has_changes=false" >> $GITHUB_OUTPUT
+          fi
+
+      - name: Commit and push changes
+        if: steps.check-changes.outputs.has_changes == 'true'
+        run: |
+          git config --local user.email "action@github.com"
+          git config --local user.name "GitHub Action"
+          git add dist/
+          git commit -m "chore: auto-build dist from src changes [skip ci]"
+          git push


### PR DESCRIPTION
## 概要

`src/`配下のファイルが変更された際に、自動でビルドを実行し、`dist/`の変更をコミット・プッシュするGitHub Actionsワークフローを追加しました。

## 変更内容

### 自動ビルド・コミットワークフロー (`.github/workflows/build-and-commit.yml`)

- **トリガー条件:**
  - `src/**`配下のファイルが変更されたpush時に実行
  - `package.json`、`package-lock.json`、`tsconfig.json`の変更でも実行
  - mainブランチへのpush時のみ実行

- **処理フロー:**
  1. Node.js環境をセットアップ
  2. 依存関係をインストール
  3. ビルドを実行（`npm run build`）
  4. `dist/`に変更があるかチェック
  5. 変更があれば自動でコミット・プッシュ

- **無限ループ防止:**
  - `dist/`の変更ではワークフローをトリガーしない（`paths`で`src/**`のみ指定）
  - 自動コミットには`[skip ci]`タグを付与
  - `[skip ci]`を含むコミットでは実行しない

## 効果

- `src/`配下のファイルを変更してmainブランチにpushすると、自動で`dist/`が更新される
- 手動でビルド・コミットする必要がなくなる
- 常に最新のビルド済みコードがリポジトリに保持される

## 関連

この変更により、PR #6で追加したGCSアップロードログ改善のコードが、自動で`dist/`に反映されるようになります。