### PR TITLE
feat: システムプロンプトの外部化機能を追加

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -29,6 +29,21 @@ inputs:
     description: 'Signed URL expiry in seconds (default: 2592000 = 30 days)'
     required: false
     default: '2592000'
+  system-prompt-wf:
+    description: 'Custom system prompt template for wireframe images. Supports placeholders: {{imageNumber}}, {{totalCount}}, {{aspect}}, {{fullContext}}'
+    required: false
+  system-prompt-concept:
+    description: 'Custom system prompt template for concept images. Supports placeholders: {{imageNumber}}, {{totalCount}}, {{aspect}}, {{fullContext}}'
+    required: false
+  system-prompt-custom:
+    description: 'Custom system prompt template for custom images. Supports placeholders: {{imageNumber}}, {{totalCount}}, {{aspect}}, {{fullContext}}, {{customInstruction}}'
+    required: false
+  system-prompt-wf-aspects:
+    description: 'Comma-separated list of aspects for wireframe images (e.g., "layout,components,navigation,interactions")'
+    required: false
+  system-prompt-concept-aspects:
+    description: 'Comma-separated list of aspects for concept images (e.g., "design direction,visual style")'
+    required: false
 runs:
   using: 'node20'
   main: 'dist/index.js'

--- a/src/index.ts
+++ b/src/index.ts
@@ -4,7 +4,7 @@ import { parseCommand } from './parser';
 import { createAIProvider } from './ai-provider';
 import { GitHubService } from './github-service';
 import { GCSService } from './gcs-service';
-import { GCSConfig } from './types';
+import { GCSConfig, PromptConfig } from './types';
 
 async function run(): Promise<void> {
   try {
@@ -22,6 +22,32 @@ async function run(): Promise<void> {
       core.getInput('gcs-signed-url-expiry', { required: false }) || '2592000',
       10
     );
+
+    // Get prompt configuration inputs
+    const wireframeTemplate = core.getInput('system-prompt-wf', { required: false });
+    const conceptTemplate = core.getInput('system-prompt-concept', { required: false });
+    const customTemplate = core.getInput('system-prompt-custom', { required: false });
+    const wireframeAspectsInput = core.getInput('system-prompt-wf-aspects', { required: false });
+    const conceptAspectsInput = core.getInput('system-prompt-concept-aspects', { required: false });
+
+    // Build PromptConfig
+    const promptConfig: PromptConfig = {};
+    
+    if (wireframeTemplate) {
+      promptConfig.wireframeTemplate = wireframeTemplate;
+    }
+    if (conceptTemplate) {
+      promptConfig.conceptTemplate = conceptTemplate;
+    }
+    if (customTemplate) {
+      promptConfig.customTemplate = customTemplate;
+    }
+    if (wireframeAspectsInput) {
+      promptConfig.wireframeAspects = wireframeAspectsInput.split(',').map(a => a.trim()).filter(a => a.length > 0);
+    }
+    if (conceptAspectsInput) {
+      promptConfig.conceptAspects = conceptAspectsInput.split(',').map(a => a.trim()).filter(a => a.length > 0);
+    }
 
     core.info('Starting gen-visual action...');
 
@@ -77,7 +103,7 @@ async function run(): Promise<void> {
     const gcsService = new GCSService(gcsConfig);
 
     // Create AI provider
-    const provider = createAIProvider(aiProvider, aiApiKey, modelName);
+    const provider = createAIProvider(aiProvider, aiApiKey, modelName, promptConfig);
 
     // Generate images
     core.info('Generating images...');

--- a/src/prompts.ts
+++ b/src/prompts.ts
@@ -1,0 +1,79 @@
+/**
+ * Default prompt templates for image generation
+ */
+
+export const wireframeAspects = [
+  'main page layout and overall structure',
+  'detailed UI components and their placement',
+  'navigation flow and menu structure',
+  'user interaction points and key features'
+];
+
+export const conceptAspects = [
+  'overall user interface design direction and visual style',
+  'key visual elements, branding, and color scheme'
+];
+
+export interface PromptParams {
+  imageNumber: number;
+  totalCount: number;
+  aspect: string;
+  fullContext: string;
+  customInstruction?: string;
+}
+
+/**
+ * Build a wireframe prompt
+ */
+export function buildWireframePrompt(params: PromptParams): string {
+  const { imageNumber, totalCount, aspect, fullContext } = params;
+  
+  return `Create a wireframe image (${imageNumber}/${totalCount}) for the following requirement that shows ${aspect}:
+
+${fullContext}
+
+Generate a clear wireframe diagram that shows ${aspect}. The wireframe should be clean, well-organized, and easy to understand, using typical wireframe conventions (boxes, labels, simple shapes).`;
+}
+
+/**
+ * Build a concept prompt
+ */
+export function buildConceptPrompt(params: PromptParams): string {
+  const { imageNumber, totalCount, aspect, fullContext } = params;
+  
+  return `Create a concept image (${imageNumber}/${totalCount}) for the following requirement that shows ${aspect}:
+
+${fullContext}
+
+Generate a high-quality concept visualization that clearly demonstrates ${aspect}. The image should be professional and visually appealing.`;
+}
+
+/**
+ * Build a custom prompt
+ */
+export function buildCustomPrompt(params: PromptParams): string {
+  const { imageNumber, totalCount, fullContext, customInstruction } = params;
+  
+  return `Create a custom image (${imageNumber}/${totalCount}) based on the following requirements and custom instruction:
+
+${fullContext}
+
+Custom instruction: ${customInstruction || ''}
+
+Generate a high-quality image that fulfills the above requirements and follows the custom instruction. The image should be professional and visually appealing.`;
+}
+
+/**
+ * Replace placeholders in a template string
+ */
+export function replacePlaceholders(template: string, params: PromptParams): string {
+  let result = template;
+  
+  result = result.replace(/\{\{imageNumber\}\}/g, String(params.imageNumber));
+  result = result.replace(/\{\{totalCount\}\}/g, String(params.totalCount));
+  result = result.replace(/\{\{aspect\}\}/g, params.aspect || '');
+  result = result.replace(/\{\{fullContext\}\}/g, params.fullContext);
+  result = result.replace(/\{\{customInstruction\}\}/g, params.customInstruction || '');
+  
+  return result;
+}

--- a/src/types.ts
+++ b/src/types.ts
@@ -35,3 +35,11 @@ export interface ImageGenerationResult {
   urls: string[];
   count: number;
 }
+
+export interface PromptConfig {
+  wireframeTemplate?: string;
+  conceptTemplate?: string;
+  customTemplate?: string;
+  wireframeAspects?: string[];
+  conceptAspects?: string[];
+}


### PR DESCRIPTION
## 概要

システムプロンプトをコードから分離し、GitHub Actionsの入力パラメータでカスタマイズできるようにしました。

## 変更内容

### 新規ファイル
- `src/prompts.ts` - デフォルトのプロンプトテンプレート関数を実装

### 変更ファイル
- `src/types.ts` - `PromptConfig` インターフェースを追加
- `src/ai-provider.ts` - `PromptConfig` を受け取り、外部化されたプロンプトを使用するように変更
- `src/index.ts` - GitHub Actionsの入力から `PromptConfig` を構築
- `action.yml` - システムプロンプト関連のオプション入力を追加
- `README.md` - システムプロンプトのカスタマイズ方法を追加

## 機能

- デフォルトプロンプトはコード内で管理（型安全）
- GitHub Actionsの入力でカスタムプロンプトテンプレートを指定可能
- プレースホルダーサポート: `{{imageNumber}}`, `{{totalCount}}`, `{{aspect}}`, `{{fullContext}}`, `{{customInstruction}}`
- カスタムアスペクトの指定が可能

## 使用例

```yaml
- name: Run Gen Visual Action
  uses: hosshan/gen-visual-issue@v1
  with:
    # ... 他のパラメータ ...
    system-prompt-wf: |
      Create a detailed wireframe ({{imageNumber}}/{{totalCount}}) showing {{aspect}}:
      {{fullContext}}
    system-prompt-wf-aspects: "layout,components,navigation,interactions"
```